### PR TITLE
chore: Fixes intellisense for Jest and VSCode.

### DIFF
--- a/src/app/utils/__tests__/classNames.test.ts
+++ b/src/app/utils/__tests__/classNames.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Cypress uses Chai for assertions, which conflicts with Jest.
+ * VSCode is using the types from Cypress, which is why it's complaining.
+ * This is a workaround to get VSCode to stop complaining.
+ */
+import { describe, it, expect } from "@jest/globals";
+
 import classNames from "../classNames";
 
 describe("classNames", () => {


### PR DESCRIPTION
VSCode is using the Chai assertions imported with Cypress by default. This is leading to issues with intellisense in Jest tests. This change explicitly import jest globals in jest tests.