### PR TITLE
chore: Remove extra cache step.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,6 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      - name: Cache Node Dependencies
-        uses: actions/cache@v3.3.2
-        with:
-          path: "**/node_modules"
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
-
   unit-test:
     runs-on: ubuntu-latest
     needs: install-dependencies


### PR DESCRIPTION
Cache is updated during the cleanup step, and thus does not need to be repeated in the build script.